### PR TITLE
Symmetry: Bump node.js to v20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
       - uses: ./
         with:
           version: '${{ matrix.version }}'

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     description: 'Proxy server'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
To resolve a GHA deprecation wrt. node.js 16.